### PR TITLE
Refactor/extract llm service interfaces

### DIFF
--- a/backend/src/main/java/com/example/backend/registries/LlmRegistry.java
+++ b/backend/src/main/java/com/example/backend/registries/LlmRegistry.java
@@ -1,0 +1,27 @@
+package com.example.backend.registries;
+
+import com.example.backend.services.LlmService;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class LlmRegistry {
+    private final Map<String, LlmService> mapByProvider;
+
+    public LlmRegistry(List<LlmService> llmServices) {
+        this.mapByProvider = llmServices.stream()
+                .collect(Collectors.toUnmodifiableMap(LlmService::provider, Function.identity()));
+    }
+
+    public LlmService getLlmService(String provider) {
+        LlmService service = mapByProvider.get(provider);
+        if (service == null) {
+            throw new IllegalArgumentException("Unknown LLM provider: " + provider);
+        }
+        return service;
+    }
+}

--- a/backend/src/main/java/com/example/backend/services/EmbeddingsService.java
+++ b/backend/src/main/java/com/example/backend/services/EmbeddingsService.java
@@ -1,0 +1,9 @@
+package com.example.backend.services;
+
+import com.example.backend.models.Message;
+
+import java.util.List;
+
+public interface EmbeddingsService {
+    List<float[]> embed(List<Message> messages);
+}

--- a/backend/src/main/java/com/example/backend/services/GoogleAiService.java
+++ b/backend/src/main/java/com/example/backend/services/GoogleAiService.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 // This service is responsible for interaction with Gemini via Google SDK
 @Service
-public class GoogleAiService {
+public class GoogleAiService implements LlmService {
 
     private final Client client;
     private final String model = "gemini-2.0-flash-001";
@@ -22,6 +22,12 @@ public class GoogleAiService {
         this.client = client;
     }
 
+    @Override
+    public String provider() {
+        return "Google";
+    }
+
+    @Override
     public Message getResponse(List<Message> messages) {
         // instruction goes separately from the chat history (in a json under the hood)
         Content instruction = Content.fromParts(Part.fromText("You are a helpful assistant. Be succinct - answer in 3-5 sentences."));
@@ -40,6 +46,7 @@ public class GoogleAiService {
         return new Message(response.text(), "model");
     }
 
+    @Override
     public String generateTitle(String firstPrompt) {
         Content instruction = Content.fromParts(Part.fromText("Generate a concise title for the user's message. Respond only with the title and nothing else."));
         GenerateContentConfig config = GenerateContentConfig.builder()

--- a/backend/src/main/java/com/example/backend/services/LlmService.java
+++ b/backend/src/main/java/com/example/backend/services/LlmService.java
@@ -1,0 +1,11 @@
+package com.example.backend.services;
+
+import com.example.backend.models.Message;
+
+import java.util.List;
+
+public interface LlmService {
+    String provider();
+    Message getResponse(List<Message> messages);
+    String generateTitle(String firstPrompt);
+}

--- a/backend/src/main/java/com/example/backend/services/OpenAiService.java
+++ b/backend/src/main/java/com/example/backend/services/OpenAiService.java
@@ -14,13 +14,18 @@ import java.util.List;
 
 // This service is responsible for interaction with GPT via OpenAI SDK
 @Service
-public class OpenAiService {
+public class OpenAiService implements LlmService, EmbeddingsService {
     private final OpenAIClient openAIClient;
     private final ChatModel chatModel = ChatModel.GPT_4O_MINI;
     private final EmbeddingModel embeddingModel = EmbeddingModel.TEXT_EMBEDDING_3_SMALL;
 
     public OpenAiService(OpenAIClient openAIClient) {
         this.openAIClient = openAIClient;
+    }
+
+    @Override
+    public String provider() {
+        return "OpenAI";
     }
 
     // a helper method to create a builder of a chat history (it contains all the messages)
@@ -39,6 +44,7 @@ public class OpenAiService {
         return b; // return the builder to add more messages if needed
     }
 
+    @Override
     public Message getResponse(List<Message> messages) {
         String instruction = "You are a helpful assistant. Be succinct - answer in 3-5 sentences.";
         ChatCompletionCreateParams params = createParamsBuilder(messages, instruction).build();
@@ -47,6 +53,7 @@ public class OpenAiService {
         return new Message(response, "assistant", null);
     }
 
+    @Override
     public String generateTitle(String firstPrompt) {
         ChatCompletionCreateParams.Builder b = ChatCompletionCreateParams.builder().model(chatModel);
         b.addSystemMessage("Generate a concise title for the chat based on the user's messages. Respond only with the title and nothing else.");
@@ -56,6 +63,7 @@ public class OpenAiService {
         return response;
     }
 
+    @Override
     public List<float[]> embed(List<Message> messages) {
         EmbeddingCreateParams.Builder b = EmbeddingCreateParams.builder().model(embeddingModel);
         b.inputOfArrayOfStrings(messages.stream().map(Message::getContent).toList());


### PR DESCRIPTION
Extract the LLM service interfaces and replace the switches with a registry that returns an LLM service by the LLM's provider name.